### PR TITLE
Fix timezone defaults and error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 - Accepts Unix epoch timestamps (seconds or milliseconds).
 - Support for multiple timezones with autocomplete and localStorage persistence.
 - Timezone selections persist in your browser. Use the **Reset Timezones** button to clear them.
+- Defaults to your browser's local timezone on first load.
  - 24-hour timeline visualization showing the hour of each timezone.
  - Format toggles: **Long**, **Short**, and **ISO** representations.
  - Copy-to-clipboard buttons for each converted timestamp.

--- a/src/main.ts
+++ b/src/main.ts
@@ -46,6 +46,12 @@ class App {
   private timezones: string[] = [];
   private currentFormat: FormatType = 'long';
   private lastParsedDate?: Date;
+  private resetResultsContainer(): void {
+    this.resultsDiv.innerHTML = `
+      <div id="timeline" class="timeline"></div>
+      <div id="conversion-list" class="conversion-list"></div>
+    `;
+  }
 
   constructor() {
     this.datetimeInput = document.getElementById('datetime-input') as HTMLInputElement;
@@ -100,7 +106,13 @@ class App {
       try { this.timezones = JSON.parse(stored); } catch { this.timezones = []; }
     }
     if (!this.timezones || this.timezones.length === 0) {
-      this.timezones = ['America/Los_Angeles'];
+      let tz = 'UTC';
+      try {
+        tz = Intl.DateTimeFormat().resolvedOptions().timeZone || 'UTC';
+      } catch {
+        tz = 'UTC';
+      }
+      this.timezones = [tz];
       localStorage.setItem('timezones', JSON.stringify(this.timezones));
     }
   }
@@ -188,6 +200,7 @@ class App {
       this.showError(result.error);
       return;
     }
+    this.resetResultsContainer();
     // Show results container
     this.resultsDiv.style.display = 'block';
     // Render timeline for parsed date
@@ -203,6 +216,8 @@ class App {
         <h3>Error:</h3>
         <p>${message}</p>
       </div>
+      <div id="timeline" class="timeline"></div>
+      <div id="conversion-list" class="conversion-list"></div>
     `;
     this.resultsDiv.style.display = 'block';
   }


### PR DESCRIPTION
## Summary
- default to browser timezone instead of LA
- keep timeline container when showing errors
- document browser timezone default in README

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684cc2890118832ab8d8a2c5eef07635