### PR TITLE
Add dark mode toggle and relative difference feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,6 @@
 - Format toggles: **Long**, **Short**, and **ISO** representations.
 - Copy-to-clipboard buttons for each converted timestamp.
 - Optional dark mode toggle to switch themes.
-- Relative difference display showing offset from your home timezone.
 
  ## Live Demo
  Just open `index.html` in any modern browser. No server required (can be hosted on Cloudflare Workers or any static host).

--- a/README.md
+++ b/README.md
@@ -8,9 +8,11 @@
 - Support for multiple timezones with autocomplete and localStorage persistence.
 - Timezone selections persist in your browser. Use the **Reset Timezones** button to clear them.
 - Defaults to your browser's local timezone on first load.
- - 24-hour timeline visualization showing the hour of each timezone.
- - Format toggles: **Long**, **Short**, and **ISO** representations.
- - Copy-to-clipboard buttons for each converted timestamp.
+- 24-hour timeline visualization showing the hour of each timezone.
+- Format toggles: **Long**, **Short**, and **ISO** representations.
+- Copy-to-clipboard buttons for each converted timestamp.
+- Optional dark mode toggle to switch themes.
+- Relative difference display showing offset from your home timezone.
 
  ## Live Demo
  Just open `index.html` in any modern browser. No server required (can be hosted on Cloudflare Workers or any static host).
@@ -41,6 +43,7 @@
     - A 24-hour timeline for each timezone with the converted hour highlighted.
     - A list of converted timestamps with copy buttons.
 5. **Reset Timezones** anytime using the button under the timezone input.
+6. **Toggle Dark Mode** with the button under the timezone list.
 
  ## Deployment
  Copy the entire `public/` directory to your static hosting environment (it contains `index.html`, `styles.css`, and `dist/`).

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@
     - A 24-hour timeline for each timezone with the converted hour highlighted.
     - A list of converted timestamps with copy buttons.
 5. **Reset Timezones** anytime using the button under the timezone input.
-6. **Toggle Dark Mode** with the button under the timezone list.
+6. **Toggle Dark Mode** using the button in the header.
 
  ## Deployment
  Copy the entire `public/` directory to your static hosting environment (it contains `index.html`, `styles.css`, and `dist/`).

--- a/index.html
+++ b/index.html
@@ -9,7 +9,11 @@
 <body>
     <div class="container">
         <header>
-            <h1>Date time converter</h1>
+            <div class="header-bar">
+                <h1>Date time converter</h1>
+                <button id="theme-toggle-btn" class="theme-toggle-btn" aria-describedby="theme-help" title="Toggle Dark Mode">&#9728;&#65039;</button>
+            </div>
+            <div id="theme-help" class="sr-only">Switch between light and dark theme</div>
             <p>Convert natural language or timestamp date/time strings to different timezones</p>
             <p class="tz-note">Timezones are saved in your browser. Click any timezone to remove it, or use reset to clear all</p>
         </header>
@@ -28,8 +32,6 @@
                 <button id="reset-timezones-btn" class="reset-btn" aria-describedby="reset-help">Reset Timezones</button>
                 <div id="reset-help" class="sr-only">Remove all selected timezones and reset to browser default</div>
                 <div id="timezone-list" class="timezone-list" aria-label="Selected timezones" role="list"></div>
-                <button id="theme-toggle-btn" class="theme-toggle-btn" aria-describedby="theme-help">Toggle Dark Mode</button>
-                <div id="theme-help" class="sr-only">Switch between light and dark theme</div>
             </div>
             <!-- Format selection -->
             <div class="format-section">

--- a/index.html
+++ b/index.html
@@ -28,6 +28,8 @@
                 <button id="reset-timezones-btn" class="reset-btn" aria-describedby="reset-help">Reset Timezones</button>
                 <div id="reset-help" class="sr-only">Remove all selected timezones and reset to browser default</div>
                 <div id="timezone-list" class="timezone-list" aria-label="Selected timezones" role="list"></div>
+                <button id="theme-toggle-btn" class="theme-toggle-btn" aria-describedby="theme-help">Toggle Dark Mode</button>
+                <div id="theme-help" class="sr-only">Switch between light and dark theme</div>
             </div>
             <!-- Format selection -->
             <div class="format-section">

--- a/src/dateTimeConverter.ts
+++ b/src/dateTimeConverter.ts
@@ -124,6 +124,35 @@ export class DateTimeConverter {
     }
   }
 
+  /** Get numeric offset from UTC in minutes for the given date and timezone */
+  static getTimezoneOffset(date: Date, timezone: string): number {
+    const fmt = new Intl.DateTimeFormat('en-US', {
+      timeZone: timezone,
+      timeZoneName: 'shortOffset',
+      year: 'numeric', month: '2-digit', day: '2-digit',
+      hour: '2-digit', minute: '2-digit', second: '2-digit'
+    });
+    const parts = fmt.formatToParts(date);
+    const tzPart = parts.find(p => p.type === 'timeZoneName');
+    if (!tzPart) return 0;
+    const m = tzPart.value.match(/GMT([+-])(\d{1,2})(?::?(\d{2}))?/);
+    if (!m) return 0;
+    const sign = m[1] === '+' ? 1 : -1;
+    const hours = parseInt(m[2], 10);
+    const mins = m[3] ? parseInt(m[3], 10) : 0;
+    return sign * (hours * 60 + mins);
+  }
+
+  /** Return a formatted UTC offset string like "UTC+02:00" */
+  static getOffsetString(date: Date, timezone: string): string {
+    const offset = DateTimeConverter.getTimezoneOffset(date, timezone);
+    const sign = offset >= 0 ? '+' : '-';
+    const abs = Math.abs(offset);
+    const hh = Math.floor(abs / 60).toString().padStart(2, '0');
+    const mm = (abs % 60).toString().padStart(2, '0');
+    return `UTC${sign}${hh}:${mm}`;
+  }
+
   static getAllTimezones(): string[] {
     // Fallback list for older browsers that don't support Intl.supportedValuesOf
     const commonTimezones = [

--- a/src/main.ts
+++ b/src/main.ts
@@ -223,9 +223,12 @@ class App {
   /** Reset stored timezones to default */
   private resetTimezones(): void {
     localStorage.removeItem('timezones');
+    localStorage.removeItem('theme');
     this.timezones = [];
     this.loadTimezones();
     this.renderTimezoneList();
+    document.body.classList.remove('dark');
+    this.updateThemeIcon(false);
   }
 
   private handleConvert(): void {
@@ -448,11 +451,17 @@ class App {
     });
   }
 
+  /** Update the theme toggle icon based on dark mode state */
+  private updateThemeIcon(isDark: boolean): void {
+    this.themeToggleBtn.textContent = isDark ? '\uD83C\uDF19' : '\u2600\uFE0F';
+  }
+
   /** Load theme preference from localStorage */
   private loadThemeFromStorage(): void {
     const stored = localStorage.getItem('theme');
     const dark = stored === 'dark';
     document.body.classList.toggle('dark', dark);
+    this.updateThemeIcon(dark);
   }
 
   /** Toggle dark/light theme */
@@ -460,6 +469,7 @@ class App {
     this.themeToggleBtn.addEventListener('click', () => {
       const isDark = document.body.classList.toggle('dark');
       localStorage.setItem('theme', isDark ? 'dark' : 'light');
+      this.updateThemeIcon(isDark);
     });
   }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -309,9 +309,8 @@ class App {
         const homeOff = DateTimeConverter.getTimezoneOffset(parsedDate, this.homeTimezone);
         const diffMin = off - homeOff;
         const offsetStr = DateTimeConverter.getOffsetString(parsedDate, tz);
-        let rel = '';
         if (diffMin === 0) {
-          rel = 'same as home';
+          displayText += ` (${offsetStr})`;
         } else {
           const ahead = diffMin > 0;
           const absMin = Math.abs(diffMin);
@@ -320,10 +319,9 @@ class App {
           const parts = [] as string[];
           if (h) parts.push(`${h} hour${h !== 1 ? 's' : ''}`);
           if (m) parts.push(`${m} minute${m !== 1 ? 's' : ''}`);
-          rel = parts.join(' ');
-          rel += ahead ? ' ahead' : ' behind';
+          const rel = `${parts.join(' ')} ${ahead ? 'ahead' : 'behind'}`;
+          displayText += ` (${offsetStr}, ${rel})`;
         }
-        displayText += ` (${offsetStr}, ${rel})`;
       }
       p.textContent = displayText;
       const pid = `conv-${tz.replace(/[^a-zA-Z0-9]/g, '_')}`;

--- a/src/main.ts
+++ b/src/main.ts
@@ -36,7 +36,7 @@ const TAG_COLORS: string[] = [
   '#ff9e80'  // peach
 ];
 
-const SHOW_RELATIVE_DIFF = true;
+const SHOW_RELATIVE_DIFF = false;
 
 class App {
   private datetimeInput: HTMLInputElement;

--- a/styles.css
+++ b/styles.css
@@ -88,6 +88,9 @@ button:hover {
   border-top: 4px solid #000;
   padding-top: 10px;
 }
+body.dark .results-section {
+  border-color: #fff;
+}
 .result-item {
   margin-bottom: 20px;
 }

--- a/styles.css
+++ b/styles.css
@@ -23,7 +23,12 @@ header {
 }
 header h1 {
   font-size: 2rem;
-  margin-bottom: 10px;
+  margin: 0;
+}
+.header-bar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
 }
 header p {
   font-size: 1rem;
@@ -65,8 +70,11 @@ button:hover {
   font-family: inherit;
 }
 .theme-toggle-btn {
-  margin-top: 10px;
-  border: 4px solid #000;
+  width: auto;
+  margin-left: 10px;
+  border: 2px solid #000;
+  padding: 2px 6px;
+  font-size: 0.8rem;
   background: transparent;
   color: #000;
   font-family: inherit;

--- a/styles.css
+++ b/styles.css
@@ -64,6 +64,13 @@ button:hover {
   color: #000;
   font-family: inherit;
 }
+.theme-toggle-btn {
+  margin-top: 10px;
+  border: 4px solid #000;
+  background: transparent;
+  color: #000;
+  font-family: inherit;
+}
 .tz-note {
   margin-top: 5px;
   font-size: 0.9rem;
@@ -240,6 +247,9 @@ button.convert-btn:hover {
   border-left: 2px solid #000;
   position: relative;
 }
+body.dark .hour-block {
+  border-left: 2px solid #fff;
+}
 .hour-block:first-child {
   border-left: none;
 }
@@ -270,4 +280,47 @@ button.convert-btn:hover {
   padding: 10px;
   border: 4px solid #000;
   line-height: 1;
+}
+
+/* Dark mode styles */
+body.dark {
+  background: #000;
+  color: #fff;
+}
+body.dark .container,
+body.dark header {
+  border-color: #fff;
+}
+body.dark input[type="text"],
+body.dark button,
+body.dark .reset-btn,
+body.dark .theme-toggle-btn,
+body.dark .fmt-btn,
+body.dark .tz-tag,
+body.dark .copy-btn,
+body.dark .autocomplete-dropdown,
+body.dark .result-item p {
+  background: #333;
+  color: #fff;
+  border-color: #fff;
+}
+body.dark button:hover,
+body.dark .fmt-btn:hover,
+body.dark .fmt-btn.selected,
+body.dark .reset-btn:hover,
+body.dark .tz-tag:hover,
+body.dark .copy-btn:hover,
+body.dark .theme-toggle-btn:hover,
+body.dark .autocomplete-item:hover,
+body.dark .autocomplete-item.selected {
+  background: #fff;
+  color: #000;
+}
+body.dark button.convert-btn {
+  background: #fff;
+  color: #000;
+}
+body.dark button.convert-btn:hover {
+  background: #333;
+  color: #fff;
 }


### PR DESCRIPTION
## Summary
- add optional dark mode styles and theme toggle
- display timezone offsets relative to the home timezone
- expose timezone offset helpers
- document new dark mode and relative difference features

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684d0cb71da4832ab23393fe5df74b3c