### PR TITLE
Add second date input for arithmetic

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
 - Format toggles: **Long**, **Short**, and **ISO** representations.
 - Copy-to-clipboard buttons for each converted timestamp.
 - Optional dark mode toggle to switch themes.
+- Date arithmetic with a second input box and add/subtract option.
 
  ## Live Demo
  Just open `index.html` in any modern browser. No server required (can be hosted on Cloudflare Workers or any static host).

--- a/index.html
+++ b/index.html
@@ -24,6 +24,20 @@
                 <input type="text" id="datetime-input" placeholder="Enter natural language date/time..." aria-describedby="datetime-help">
                 <div id="datetime-help" class="sr-only">Enter natural language date and time expressions or Unix timestamps</div>
             </div>
+
+            <div class="input-section">
+                <label for="datetime-input-2">Second date/time</label>
+                <input type="text" id="datetime-input-2" placeholder="Optional second date/time..." aria-describedby="datetime-help-2">
+                <div id="datetime-help-2" class="sr-only">Enter another date/time to add or subtract</div>
+            </div>
+
+            <div class="input-section">
+                <label for="operation-select">Operation:</label>
+                <select id="operation-select">
+                    <option value="add">Add</option>
+                    <option value="subtract">Subtract</option>
+                </select>
+            </div>
             
             <div class="timezone-section">
                 <label for="timezone-input">Add timezones:</label>

--- a/src/main.ts
+++ b/src/main.ts
@@ -40,6 +40,8 @@ const SHOW_RELATIVE_DIFF = false;
 
 class App {
   private datetimeInput: HTMLInputElement;
+  private datetimeInput2: HTMLInputElement;
+  private operationSelect: HTMLSelectElement;
   private timezoneInput: HTMLInputElement;
   private convertBtn: HTMLButtonElement;
   private resetBtn: HTMLButtonElement;
@@ -60,6 +62,8 @@ class App {
 
   constructor() {
     this.datetimeInput = document.getElementById('datetime-input') as HTMLInputElement;
+    this.datetimeInput2 = document.getElementById('datetime-input-2') as HTMLInputElement;
+    this.operationSelect = document.getElementById('operation-select') as HTMLSelectElement;
     this.timezoneInput = document.getElementById('timezone-input') as HTMLInputElement;
     this.convertBtn = document.getElementById('convert-btn') as HTMLButtonElement;
     this.resetBtn = document.getElementById('reset-timezones-btn') as HTMLButtonElement;
@@ -247,8 +251,24 @@ class App {
       this.showError(parseResult.error || 'Error parsing date');
       return;
     }
-    this.lastParsedDate = parseResult.parsedDate;
-    this.displayResult(parseResult);
+    let finalDate = parseResult.parsedDate;
+
+    const secondText = this.datetimeInput2.value.trim();
+    if (secondText) {
+      const secondRes = DateTimeConverter.parseAndConvert(secondText, this.timezones[0]);
+      if (secondRes.error || !secondRes.parsedDate) {
+        this.showError(secondRes.error || 'Error parsing second date');
+        return;
+      }
+      if (this.operationSelect.value === 'add') {
+        finalDate = new Date(finalDate.getTime() + secondRes.parsedDate.getTime());
+      } else {
+        finalDate = new Date(finalDate.getTime() - secondRes.parsedDate.getTime());
+      }
+    }
+
+    this.lastParsedDate = finalDate;
+    this.displayResult({ parsedDate: finalDate });
   }
 
   private displayResult(result: any): void {

--- a/styles.css
+++ b/styles.css
@@ -39,6 +39,7 @@ label {
   font-weight: bold;
 }
 input[type="text"],
+select,
 button {
   width: 100%;
   border: 4px solid #000;
@@ -303,6 +304,7 @@ body.dark header {
   border-color: #fff;
 }
 body.dark input[type="text"],
+body.dark select,
 body.dark button,
 body.dark .reset-btn,
 body.dark .theme-toggle-btn,


### PR DESCRIPTION
## Summary
- allow date arithmetic by adding a second input and a dropdown for add/subtract
- style the new select element
- document the new capability in README

## Testing
- `npm install`
- `npm run build`
- `npx tsc -p tsconfig.json`


------
https://chatgpt.com/codex/tasks/task_e_6850b9f07304832aace17eed5df589e5