### PR TITLE
chore: group dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,14 @@
 version: 2
-
 updates:
   - package-ecosystem: github-actions
-    directory: "/"
+    directory: /
     schedule:
       interval: weekly
+    groups:
+      all-version-updates:
+        patterns:
+          - '*'
+      all-security-updates:
+        applies-to: security-updates
+        patterns:
+          - '*'


### PR DESCRIPTION
Group Dependabot version and security updates for each ecosystem.